### PR TITLE
add list issue labels method

### DIFF
--- a/lib/Issue.js
+++ b/lib/Issue.js
@@ -212,6 +212,18 @@ class Issue extends Requestable {
    listLabels(options, cb) {
       return this._request('GET', `/repos/${this.__repository}/labels`, options, cb);
    }
+   
+   /**
+   * List the labels of a particular issue
+   * @see https://developer.github.com/v3/issues/labels/#list-labels-on-an-issue
+   * @param {number} issue - the id of the issue to get comments from
+   * @param {Object} data ...
+   * @param {Requestable.callback} [cb] - will receive the comments
+   * @return {Promise} - the promise for the http request
+   */
+   listIssueLabels(issue, data, cb) {
+      return this._request('GET', `/repos/${this.__repository}/issues/${issue}/labels`, data, cb);
+   }
 
   /**
    * Get a label


### PR DESCRIPTION
So as described [here](https://github.com/bluzi/travis-buddy/issues/53#issuecomment-379481842) I added the list issue labels method to the Issue lib.
I haven't tested yet if it works and I'm not sure if the `data` parameter is needed (and what it means anyway: like the one you added in the `listIssueComments` method.